### PR TITLE
feat: add support for cwd URL parameter

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -64,7 +64,9 @@ function App() {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const host = window.location.hostname || "localhost";
       const wsPort = 5174;
-      const wsUrl = `${protocol}//${host}:${wsPort}`;
+      // Include query parameters from the current URL
+      const queryParams = window.location.search;
+      const wsUrl = `${protocol}//${host}:${wsPort}${queryParams}`;
 
       console.log(`Connecting to WebSocket at ${wsUrl}`);
       const ws = new WebSocket(wsUrl);


### PR DESCRIPTION
Expected usage, in AGENT.md or equivalent

```
To test this CLI use the following URL

http://localhost:5173?cwd=<absolute-url-of-a-project-where-cli-can-be-tested>
```

Add additional instructions on how / what to test, generic stuff in AGENT.md, task specific stuff in the prompt